### PR TITLE
Fiscal Year session variable changes

### DIFF
--- a/working_code/Controllers/FDBController.cs
+++ b/working_code/Controllers/FDBController.cs
@@ -616,6 +616,7 @@ namespace MBTP.Controllers
             ViewBag.FiscalYearStartDate = fiscalYearStartDate;
             ViewBag.FiscalYear = fiscalYear;
             return data;
+        }
     }
 }
 

--- a/working_code/Controllers/HomeController.cs
+++ b/working_code/Controllers/HomeController.cs
@@ -74,6 +74,15 @@ namespace MBTP.Controllers
         }
         public IActionResult FDB()
         {
+            string? fiscalYear = HttpContext.Session.GetString("FiscalYear");
+            if (string.IsNullOrEmpty(fiscalYear))
+            {
+                DateTime today = DateTime.Today;
+                fiscalYear = (today.Month >= 10) ? $"{today.Year}" : $"{today.Year - 1}";
+                HttpContext.Session.SetString("FiscalYear", fiscalYear);
+                HttpContext.Session.SetString("ThisFiscalYear", fiscalYear);
+                HttpContext.Session.SetString("IsCurrentFiscalYear", "true");
+            }
             return View();
         }
         public IActionResult Newbook()
@@ -416,7 +425,9 @@ namespace MBTP.Controllers
         [HttpPost]
         public async Task<IActionResult> Logout()
         {
-
+            HttpContext.Session.Remove("FiscalYear");
+            HttpContext.Session.Remove("ThisFiscalYear");
+            HttpContext.Session.Remove("IsCurrentFiscalYear");
             await HttpContext.SignOutAsync(CookieAuthenticationDefaults.AuthenticationScheme);
             return RedirectToAction("Login");
         }

--- a/working_code/Monthly.cs
+++ b/working_code/Monthly.cs
@@ -65,8 +65,10 @@ namespace MBTP.Retrieval
                 currentMonthTotal = ComputeTotal(currentMonthData);
                 previousMonthTotal = ComputeTotal(previousMonthData);
 
+                // Commented out 9/2/25 by Dave because this comparison is incomplete, only relying on Site Totals. It's also deceptive
+                // because certain months will always be lower than others due to seasonality.
                 // Determine if the current month is positive compared to the previous month
-                isPositive = currentMonthTotal >= previousMonthTotal;
+                //isPositive = currentMonthTotal >= previousMonthTotal;
             }
             catch (SqlException sqlEx)
             {

--- a/working_code/Views/Shared/_Layout.cshtml
+++ b/working_code/Views/Shared/_Layout.cshtml
@@ -169,8 +169,9 @@ input:checked + .slider:before {
                                         <label for="yearSelect" class="fyLabel">Fiscal Year Selected:</label>
                                         @{
                                             var fiscalYear = Context.Session.GetString("FiscalYear") ?? "2024";
+                                            var thisFiscalYear = Context.Session.GetString("ThisFiscalYear");
                                         }
-                                        <input class="fyInput" type="number" value="@fiscalYear" min="2022" max="2024" step="1" id="yearSelect" />
+                                        <input class="fyInput" type="number" value="@fiscalYear" min="2022" max="@thisFiscalYear" step="1" id="yearSelect" />
                                     </li>
                                 }
                             }


### PR DESCRIPTION
Added code to define the fiscal year session variables upon first entry to FDB so they are always defined prior to hitting a financial page.  Also added code to Logout method in Home Controller to remove the variables.
Commented out isPositive calculation in Monthly.cs because the calculation was flawed.  It will always be true until further exploration is warranted.
Fixed layout.cshtml so max value for fiscal year dropdown is calculated and not hardcoded.