### PR TITLE
fixed blackout reason with non-breaking hyphen

### DIFF
--- a/working_code/Views/FDB/DailyBreakdownA.cshtml
+++ b/working_code/Views/FDB/DailyBreakdownA.cshtml
@@ -119,7 +119,7 @@
                     {
                         blackoutReason = "No reason provided";
                     }
-                    <td class="alertData" colspan="4"><b>CLOSED - @blackoutReason.ToUpper()</b></td>
+                    <td class="alertData"><b>CLOSED&nbsp;&#8209;&nbsp;@blackoutReason.ToUpper()</b></td>
                 }
                 else
                 {

--- a/working_code/Views/FDB/DailyBreakdownC.cshtml
+++ b/working_code/Views/FDB/DailyBreakdownC.cshtml
@@ -121,7 +121,7 @@
                     {
                         blackoutReason = "No reason provided";
                     }
-                    <td class="alertData" colspan="3"><b>CLOSED - @blackoutReason.ToUpper()</b></td>
+                    <td class="alertData" colspan="3"><b>CLOSED&nbsp;&#8209;&nbsp;@blackoutReason.ToUpper()</b></td>
                 }
                 else
                 {

--- a/working_code/Views/FDB/DailyBreakdownG.cshtml
+++ b/working_code/Views/FDB/DailyBreakdownG.cshtml
@@ -207,7 +207,7 @@
                     {
                         blackoutReason = "No reason provided";
                     }
-                    <td class="alertData" colspan="4"><b>CLOSED - @blackoutReason.ToUpper()</b></td>
+                    <td class="alertData" colspan="7"><b>CLOSED&nbsp;&#8209;&nbsp;@blackoutReason.ToUpper()</b></td>
                 }
                 else
                 {

--- a/working_code/Views/FDB/DailyBreakdownK.cshtml
+++ b/working_code/Views/FDB/DailyBreakdownK.cshtml
@@ -150,7 +150,7 @@
                     {
                         blackoutReason = "No reason provided";
                     }
-                    <td class="alertData" colspan="4"><b>CLOSED - @blackoutReason.ToUpper()</b></td>
+                    <td class="alertData" colspan="4"><b>CLOSED&nbsp;&#8209;&nbsp;@blackoutReason.ToUpper()</b></td>
                 }
                 else
                 {


### PR DESCRIPTION
replaced standard hyphen with non-breaking hyphen when blackout reason is listed on daily breakdown pages